### PR TITLE
Fix eslint error

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,10 +14,10 @@
         "argsIgnorePattern": "^_"
       }
     ],
-    "parserOptions": {
-      "ecmaVersion": 2021,
-      "sourceType": "module"
-    },
     "@typescript-eslint/no-empty-interface": 0
+  },
+  "parserOptions": {
+    "ecmaVersion": 2021,
+    "sourceType": "module"
   }
 }


### PR DESCRIPTION
Fix next error: 
ERROR
[eslint] .eslintrc:
	Configuration for rule "parserOptions" is invalid:
	Severity should be one of the following: 0 = off, 1 = warn, 2 = error (you passed '{ ecmaVersion: 2021, sourceType: "module" }').